### PR TITLE
add type definition for creating CancelToken as class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,12 @@ declare module '@avocode/cancel-token' {
   }
 
   interface TokenSource {
+    new (): {
+      cancel: (reason?: Error | string) => void
+      dispose: () => void
+      token: CancelToken
+    }
+
     (): {
       cancel: (reason?: Error | string) => void
       dispose: () => void


### PR DESCRIPTION
there was a type error in TS when creating CancelToken as constructable class `new CancelToken`